### PR TITLE
新增NonDynamicMethod 特性，解决指定的方法不映射为对应的api接口，并实现相关的方法

### DIFF
--- a/samples/Panda.DynamicWebApiSample/Dynamic/AppleAppService.cs
+++ b/samples/Panda.DynamicWebApiSample/Dynamic/AppleAppService.cs
@@ -53,6 +53,7 @@ namespace Panda.DynamicWebApiSample.Dynamic
         /// Get  All Apple Async.
         /// </summary>
         /// <returns></returns>
+        //[NonDynamicMethod]
         public IEnumerable<string> GetAllAsync()
         {
             return Apples.Values;

--- a/src/Panda.DynamicWebApi/Attributes/NonDynamicMethodAttribute.cs
+++ b/src/Panda.DynamicWebApi/Attributes/NonDynamicMethodAttribute.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Panda.DynamicWebApi.Attributes
+{
+    [Serializable]
+    [AttributeUsage(AttributeTargets.Interface | AttributeTargets.Class | AttributeTargets.Method)]
+    public class NonDynamicMethodAttribute : Attribute
+    {
+
+    }
+}


### PR DESCRIPTION
在我写的框架里，我用了这一套开发组件，但我发现 NonDynamicWebApiAttribute 只能映射在对应的AppService 类级别，指定的方法标识该特性，会出现异常把报错，主要action.ApiExplorer.IsVisible 为true，我新增一个特性，在相关的映射方法里面做了过滤，解决方法级别不映射的问题。相关内容回馈到开源项目中。